### PR TITLE
Fix worker code, add version updates

### DIFF
--- a/application/static/worker.js
+++ b/application/static/worker.js
@@ -1,4 +1,6 @@
-const files = [
+// Change version here in case of static content updates
+const CACHE_NAME = 'metarhia-static-v1';
+const CACHE_FILES = [
   '/',
   '/console.css',
   '/events.js',
@@ -10,16 +12,46 @@ const files = [
   '/metarhia.svg',
 ];
 
-self.addEventListener('install', async (event) => {
-  const cache = await caches.open('metarhia');
-  event.waitUntil(cache.addAll(files));
-});
+async function registerContent() {
+  const cache = await caches.open(CACHE_NAME);
+  return cache.addAll(CACHE_FILES);
+}
 
-self.addEventListener('fetch', async ({ request }) => {
-  const cache = await caches.open('metarhia');
-  const cached = await cache.match(request);
+async function checkVersionUpdates() {
+  const cacheWhitelist = [CACHE_NAME];
+  const cacheNames = await caches.keys();
+  return Promise.all(
+    cacheNames.map((name) => {
+      if (!cacheWhitelist.includes(name)) return caches.delete(name);
+    })
+  );
+}
+
+async function getContent(request) {
+  const cached = await caches.match(request);
   if (cached) return cached;
   const response = await fetch(request);
-  if (response.status < 400) cache.put(request, response.clone());
+  if (response && response.status === 200 && response.type === 'basic') {
+    const cache = await caches.open(CACHE_NAME);
+    cache.put(request, response.clone());
+  }
   return response;
+}
+
+self.addEventListener('install', (event) => {
+  const contentRegistration = registerContent();
+  event.waitUntil(contentRegistration);
+});
+
+self.addEventListener('activate', (event) => {
+  const versionChecking = checkVersionUpdates();
+  event.waitUntil(versionChecking);
+});
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  if (request.url.startsWith('http')) {
+    const contentRetrieving = getContent(request);
+    event.respondWith(contentRetrieving);
+  }
 });

--- a/application/static/worker.js
+++ b/application/static/worker.js
@@ -12,12 +12,12 @@ const CACHE_FILES = [
   '/metarhia.svg',
 ];
 
-async function registerContent() {
+const registerContent = async () => {
   const cache = await caches.open(CACHE_NAME);
   return cache.addAll(CACHE_FILES);
-}
+};
 
-async function checkVersionUpdates() {
+const checkVersionUpdates = async () => {
   const cacheWhitelist = [CACHE_NAME];
   const cacheNames = await caches.keys();
   return Promise.all(
@@ -25,9 +25,9 @@ async function checkVersionUpdates() {
       if (!cacheWhitelist.includes(name)) return caches.delete(name);
     })
   );
-}
+};
 
-async function getContent(request) {
+const getContent = async (request) => {
   const cached = await caches.match(request);
   if (cached) return cached;
   const response = await fetch(request);
@@ -36,7 +36,7 @@ async function getContent(request) {
     cache.put(request, response.clone());
   }
   return response;
-}
+};
 
 self.addEventListener('install', (event) => {
   const contentRegistration = registerContent();


### PR DESCRIPTION
Refs: #85

- Fix existing errors related to service worker
- Add content version updates
- Refactor service worker code

Fixed errors:
`worker.js:15 Uncaught (in promise) DOMException: Failed to execute 'waitUntil' on 'ExtendableEvent': The event handler is already finished and no extend lifetime promises are outstanding.
    at http://localhost:8001/worker.js:15:9` (closes #85)

`Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Request scheme 'chrome-extension' is unsupported
    at worker.js:23` (escaleted if user has requests to extensions)
  