### PR TITLE
Check db startup and pass siginin error code

### DIFF
--- a/application/api/auth.2/signin.js
+++ b/application/api/auth.2/signin.js
@@ -2,10 +2,10 @@
   access: 'public',
   method: async ({ login, password }) => {
     const user = await api.auth.provider.getUser(login);
-    if (!user) throw new Error('Incorrect login or password');
+    if (!user) throw new Error('Incorrect login or password', 403);
     const { accountId, password: hash } = user;
     const valid = await metarhia.metautil.validatePassword(password, hash);
-    if (!valid) throw new Error('Incorrect login or password');
+    if (!valid) throw new Error('Incorrect login or password', 403);
     console.log(`Logged user: ${login}`);
     const token = api.auth.provider.generateToken();
     const data = { accountId: user.accountId };

--- a/application/db/pg/start.js
+++ b/application/db/pg/start.js
@@ -4,4 +4,12 @@ async () => {
   }
   const options = { ...config.database, console };
   db.pg = new metarhia.metasql.Database(options);
+
+  // Check that we connected successfully.
+  await db.pg.query('SELECT now()').catch((err) => {
+    if (application.worker.id === 'W1') {
+      console.error(`Failed to setup DB: ${err.message}`);
+    }
+    process.exit(0);
+  });
 };


### PR DESCRIPTION
* Check DB connection status during startup
  otherwise we will get random `unhandledRejection` or `500` errors during API calls with errors like `Password authentication failed for user` with a long PG stacktrace

* Pass 403 error code in signin