### PR TITLE
Fix Docker env error: Cannot find module 'node:fs'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:14
+FROM node:16-alpine
 WORKDIR /usr/server
 COPY . .
 RUN npm ci --only=production

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ let's start with
 
 ## Usage
 
-- You need node.js v14 or later
+- You need node.js v16 or later
 - Fork and clone this repository (optionally subscribe to repo changes)
 - Run `npm i` to install dependencies and generate RSA certificate
 - Remove unneeded dependencies if your project doesn't require them
 - Add your license to `LICENSE` file but don't remove starter kit license
 - Start your project modifying this starter kit
+- If you have Docker and Docker Compose installed to run the project, use the command: `docker-compose up`
 - Before running server initialize the DB:
   - First of all, make sure you have PostgreSQL installed (prefer 12.x).
   - Run database initialization script: `database/setup.sh`


### PR DESCRIPTION
This pull request fixes the error below, which appears in the log after running command `docker-compose up` and also updates the Node.js version in the README.

```
api-example  | internal/modules/cjs/loader.js:905
api-example  |   throw err;
api-example  |   ^
api-example  | 
api-example  | Error: Cannot find module 'node:fs'
api-example  | Require stack:
api-example  | - /usr/server/node_modules/impress/impress.js
api-example  | - /usr/server/server.js
api-example  |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
api-example  |     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
api-example  |     at Module.require (internal/modules/cjs/loader.js:974:19)
api-example  |     at require (internal/modules/cjs/helpers.js:92:18)
api-example  |     at Object.<anonymous> (/usr/server/node_modules/impress/impress.js:5:13)
api-example  |     at Module._compile (internal/modules/cjs/loader.js:1085:14)
api-example  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
api-example  |     at Module.load (internal/modules/cjs/loader.js:950:32)
api-example  |     at Function.Module._load (internal/modules/cjs/loader.js:790:14)
api-example  |     at Module.require (internal/modules/cjs/loader.js:974:19) {
api-example  |   code: 'MODULE_NOT_FOUND',
api-example  |   requireStack: [
api-example  |     '/usr/server/node_modules/impress/impress.js',
api-example  |     '/usr/server/server.js'
api-example  |   ]
api-example  | }
api-example  | 
```

The repository currently used for the Docker image https://github.com/mhart/alpine-node is already archived, so I have changed the Docker image to use the official Node.js Docker image.
