### PR TITLE
Fix wrong references to redis and outdated callback interface use

### DIFF
--- a/application/api/example/redisGet.js
+++ b/application/api/example/redisGet.js
@@ -1,7 +1,7 @@
 ({
   access: 'public',
   method: async ({ key }) => {
-    const result = await lib.redis.get(key);
+    const result = await db.redis.get(key);
     return { result };
   },
 });

--- a/application/api/example/redisSet.js
+++ b/application/api/example/redisSet.js
@@ -1,7 +1,7 @@
 ({
   access: 'public',
   method: async ({ key, value }) => {
-    const result = await lib.redis.set(key, value);
+    const result = await db.redis.set(key, value);
     return { result };
   },
 });

--- a/application/db/redis/get.js
+++ b/application/db/redis/get.js
@@ -1,7 +1,1 @@
-(key) =>
-  new Promise((resolve, reject) => {
-    lib.redis.client.get(key, (err, result) => {
-      if (err) reject(err);
-      else resolve(result);
-    });
-  });
+(key) => db.redis.client.get(key);

--- a/application/db/redis/set.js
+++ b/application/db/redis/set.js
@@ -1,1 +1,1 @@
-(key, value) => db.redis.client.set(key, value);
+(key, value, options) => db.redis.client.set(key, value, options);

--- a/application/db/redis/set.js
+++ b/application/db/redis/set.js
@@ -1,7 +1,1 @@
-(key, value) =>
-  new Promise((resolve, reject) => {
-    lib.redis.client.set(key, value, (err, result) => {
-      if (err) reject(err);
-      else resolve(result);
-    });
-  });
+(key, value) => db.redis.client.set(key, value);


### PR DESCRIPTION
There is an errors in redis access logic that this PR fixes.

### Way to reproduce

1. Uncomment Redis connection establishing at https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/db/redis/start.js#L13 
2. Start the redis server in your environment on default port and application server itself `node server.js` 
3. Open browser tab with application and DevConsole
4. Type in console tab of DevConsole `await api.example.redisSet({ key: 'one', value: 1 });`
5. You will receive "Internal Server Error"  and server log will contain

```
11:03:38  W3   error   127.0.0.1	GET	/api	500	500	TypeError: Cannot read properties of undefined (reading 'set')
  method (/application/api/example/redisSet.js:4:36)
  Procedure.invoke (/node_modules/impress/lib/procedure.js:78:22)
  Server.rpc (/node_modules/metacom/lib/server.js:267:27)
  process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Resolving

Fix wrong references to `lib.redis` that doesn't actually exist in 
https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/db/redis/get.js#L3
https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/db/redis/set.js#L3
as well as references to this methods from 
https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/api/example/redisSet.js#L4
https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/api/example/redisGet.js#L4

The Redis client and adapter methods available from the `db` namespace.

However after that fix reveals another problem: retrying both `await api.example.redisSet({ key: 'one', value: 1 });` and `await api.example.redisGet({ key: 'one' });` results in no WS message return at all with an `Error: Request timeout` happened on the client side (the server log was silent). 

Version of [Redis driver](https://github.com/redis/node-redis) 4.6.7 that used in the project already utilizes Promise interface instead of callbacks. So promisifying functions `get.js` and `set.js`  updated to thin adapters. As an extra enhancement I had added `options` argument into `set.js` to comply with actual client's interface.
 