### PR TITLE
Enable `api.js` test cases that were omitted

### DIFF
--- a/application/domain/tests/api.js
+++ b/application/domain/tests/api.js
@@ -1,12 +1,15 @@
 ({
   async cases(t, metacom) {
     if (!t) return;
-    const res = await metacom.api.auth.signin({
-      login: 'marcus',
-      password: 'marcus',
+
+    await t.test('Sign into session', async () => {
+      const res = await metacom.api.auth.signin({
+        login: 'marcus',
+        password: 'marcus',
+      });
+      node.assert.strictEqual(res.status, 'logged');
+      node.assert.strictEqual(typeof res.token, 'string');
     });
-    node.assert.strictEqual(res.status, 'logged');
-    node.assert.strictEqual(typeof res.token, 'string');
 
     await t.test(`Call example.add({ a, b })`, async () => {
       const res = await metacom.api.example.add({ a: 10, b: 20 });


### PR DESCRIPTION
Closes: https://github.com/metarhia/Example/issues/263

The cause appears to be a tiny typo in a first guard line at https://github.com/metarhia/Example/blob/2435b8e643af3fc4a62fea1f3f20bdedc1e1d9c1/application/domain/tests/api.js#L2-L3

Reverse of the check enables assertions and cases from the script. Console result of the `npm t` now shows its execution

```sh
13:14:16  W1   debug   ✅ Passed: Get room with domain.chat.getRoom (0.234334ms)
13:14:16  W1   debug   ✅ Passed: Send message with domain.chat.send (0.09725ms)
13:14:16  W1   debug   ✅ Passed: Chat test (1.097958ms)
13:14:16  W2   debug   127.0.0.1        POST    /api    200
13:14:16  W2   log     127.0.0.1        system/introspect
13:14:16  W2   debug   SELECT * FROM "Account" WHERE "login" = $1       [marcus]
13:14:17  W2   log     Logged user: marcus
13:14:17  W2   log     {
  createSession: {
    token: 'aNzY51hcAKpQVXtoS9xXzpnBGNF83NdMZ9YYEwG4ofbqhbZ2NG4u8MVV3FdW5db7',
    data: '{"accountId":"2"}',
    ip: '127.0.0.1',
    accountId: '2'
  }
}
13:14:17  W2   debug   INSERT INTO "Session" ("token", "data", "ip", "accountId") VALUES ($1, $2, $3, $4) RETURNING *   [aNzY51hcAKpQVXtoS9xXzpnBGNF83NdMZ9YYEwG4ofbqhbZ2NG4u8MVV3FdW5db7,{"accountId":"2"},127.0.0.1,2]
13:14:17  W2   debug   127.0.0.1        POST    /api    200
13:14:17  W2   log     127.0.0.1        auth/signin
13:14:17  W2   debug   127.0.0.1        POST    /api    200
13:14:17  W2   log     127.0.0.1        example/add
13:14:17  W1   debug   ✅ Passed: Call example.add({ a, b }) (2.3935ms)
13:14:17  W1   debug   ✅ Passed: Metacom over HTTP (112.830125ms)
13:14:17  W1   debug   127.0.0.1        GET     /demo.txt       200
13:14:17  W1   debug   ✅ Passed: Test to serve without cache (5.920542ms)
13:14:17  W3   debug   127.0.0.1        GET     /       200
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/ (6.396459ms)
13:14:17  W1   debug   127.0.0.1        GET     /console.js     200
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/console.js (2.886916ms)
13:14:17  W1   error   127.0.0.1        GET     /unknown        404
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/unknown (5.30275ms)
13:14:17  W1   error   127.0.0.1        GET     /unknown.png    404
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/unknown.png (1.873792ms)
13:14:17  W1   error   127.0.0.1        GET     /unknown/unknown        404
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/unknown/unknown (1.914459ms)
13:14:17  W1   error   127.0.0.1        GET     /unknown/unknown.png    404
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/unknown/unknown.png (1.583125ms)
13:14:17  W1   debug   127.0.0.1        GET     /article        200
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/article (1.344333ms)
13:14:17  W1   debug   127.0.0.1        GET     /article/file.txt       200
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/article/file.txt (1.523125ms)
13:14:17  W1   debug   127.0.0.1        GET     /article/name   200
13:14:17  W1   debug   ✅ Passed: Get static resource: http://127.0.0.1:8000/article/name (1.151792ms)
13:14:17  W1   debug   ✅ Passed: Static server test (31.472667ms)
13:14:17  W2   log     127.0.0.1        system/introspect
13:14:17  W2   debug   SELECT * FROM "Account" WHERE "login" = $1       [marcus]
13:14:17  W2   log     Logged user: marcus
13:14:17  W2   log     {
  createSession: {
    token: '1GSI5hJQuIX98Cb6uMVrctQDhpPUDfqLi9s0U2wowKN6t7MUSrm5YDcS69Bpf262',
    data: '{"accountId":"2"}',
    ip: '127.0.0.1',
    accountId: '2'
  }
}
13:14:17  W2   debug   INSERT INTO "Session" ("token", "data", "ip", "accountId") VALUES ($1, $2, $3, $4) RETURNING *   [1GSI5hJQuIX98Cb6uMVrctQDhpPUDfqLi9s0U2wowKN6t7MUSrm5YDcS69Bpf262,{"accountId":"2"},127.0.0.1,2]
13:14:17  W2   log     127.0.0.1        auth/signin
13:14:17  W2   log     127.0.0.1        example/add
13:14:17  W1   debug   ✅ Passed: Call example.add({ a, b }) (0.380292ms)
13:14:17  W1   debug   ✅ Passed: Metacom over Websocket (76.290041ms)
13:14:17  W1   debug   🟢 Passed 18, Failed: 0
```

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated
- [x] code is properly formatted (`npm run fmt`)