### PR TITLE
Remove unnecessary `fullName` argument in `api.auth.register`

### DIFF
--- a/application/api/auth/register.js
+++ b/application/api/auth/register.js
@@ -1,8 +1,8 @@
 ({
   access: 'public',
-  method: async ({ login, password, fullName }) => {
+  method: async ({ login, password }) => {
     const hash = await metarhia.metautil.hashPassword(password);
-    await api.auth.provider.registerUser(login, hash, fullName);
+    await api.auth.provider.registerUser(login, hash);
     const token = await context.client.startSession();
     return { status: 'success', token };
   },


### PR DESCRIPTION
`api.auth.provider.registerUser(login, password)` accept only two arguments, so `fullName` is not required.

- fullName has been removed.